### PR TITLE
Migrate java version

### DIFF
--- a/YConnectServletSDK/src/jp/co/yahoo/yconnect/core/util/YConnectLogger.java
+++ b/YConnectServletSDK/src/jp/co/yahoo/yconnect/core/util/YConnectLogger.java
@@ -44,6 +44,10 @@ public class YConnectLogger {
         if (System.getProperty("log4j2.configurationFile") == null) {
             System.setProperty("log4j2.configurationFile", CONF_FILE);
         }
+        if (System.getenv("YCONNECT_LOGGING_CONF_PATH") != null) {
+            System.setProperty(
+                    "log4j2.configurationFile", System.getenv("YCONNECT_LOGGING_CONF_PATH"));
+        }
     }
 
     private static final Logger log = LogManager.getLogger(YConnectLogger.class.getName());

--- a/YConnectServletSDK/src/jp/co/yahoo/yconnect/core/util/YConnectLogger.java
+++ b/YConnectServletSDK/src/jp/co/yahoo/yconnect/core/util/YConnectLogger.java
@@ -36,8 +36,14 @@ public class YConnectLogger {
 
     private static String CONF_FILE = "yconnect_log_conf.xml";
 
+    public static void setFilePath(String path) {
+        YConnectLogger.CONF_FILE = path;
+    }
+
     static {
-        System.setProperty("log4j2.configurationFile", CONF_FILE);
+        if (System.getProperty("log4j2.configurationFile") == null) {
+            System.setProperty("log4j2.configurationFile", CONF_FILE);
+        }
     }
 
     private static final Logger log = LogManager.getLogger(YConnectLogger.class.getName());
@@ -60,9 +66,5 @@ public class YConnectLogger {
 
     public static void fatal(Object object, String message) {
         log.fatal("{} ({})", message, object.getClass().getName());
-    }
-
-    public static void setFilePath(String path) {
-        YConnectLogger.CONF_FILE = path;
     }
 }

--- a/YConnectServletSDK/src/jp/co/yahoo/yconnect/core/util/YConnectLogger.java
+++ b/YConnectServletSDK/src/jp/co/yahoo/yconnect/core/util/YConnectLogger.java
@@ -24,8 +24,8 @@
 
 package jp.co.yahoo.yconnect.core.util;
 
-import org.apache.log4j.Logger;
-import org.apache.log4j.xml.DOMConfigurator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * YConnect Logger Class
@@ -34,33 +34,32 @@ import org.apache.log4j.xml.DOMConfigurator;
  */
 public class YConnectLogger {
 
-    private static final Logger log = Logger.getLogger(YConnectLogger.class.getName());
-
     private static String CONF_FILE = "yconnect_log_conf.xml";
 
+    static {
+        System.setProperty("log4j2.configurationFile", CONF_FILE);
+    }
+
+    private static final Logger log = LogManager.getLogger(YConnectLogger.class.getName());
+
     public static void debug(Object object, String message) {
-        DOMConfigurator.configure(CONF_FILE);
-        log.debug(message + " (" + object.getClass().getName() + ")");
+        log.debug("{} ({})", message, object.getClass().getName());
     }
 
     public static void info(Object object, String message) {
-        DOMConfigurator.configure(CONF_FILE);
-        log.info(message + " (" + object.getClass().getName() + ")");
+        log.info("{} ({})", message, object.getClass().getName());
     }
 
     public static void warn(Object object, String message) {
-        DOMConfigurator.configure(CONF_FILE);
-        log.warn(message + " (" + object.getClass().getName() + ")");
+        log.warn("{} ({})", message, object.getClass().getName());
     }
 
     public static void error(Object object, String message) {
-        DOMConfigurator.configure(CONF_FILE);
-        log.error(message + " (" + object.getClass().getName() + ")");
+        log.error("{} ({})", message, object.getClass().getName());
     }
 
     public static void fatal(Object object, String message) {
-        DOMConfigurator.configure(CONF_FILE);
-        log.fatal(message + " (" + object.getClass().getName() + ")");
+        log.fatal("{} ({})", message, object.getClass().getName());
     }
 
     public static void setFilePath(String path) {

--- a/YConnectServletSDK/test/build.gradle
+++ b/YConnectServletSDK/test/build.gradle
@@ -3,8 +3,9 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
 }
 
 repositories {

--- a/YConnectServletSDK/test/build.gradle
+++ b/YConnectServletSDK/test/build.gradle
@@ -8,6 +8,10 @@ java {
     }
 }
 
+tasks.withType(JavaCompile) {
+    options.encoding("UTF-8")
+}
+
 repositories {
     mavenCentral()
 }

--- a/YConnectServletSDK/test/yconnect_log_conf.xml
+++ b/YConnectServletSDK/test/yconnect_log_conf.xml
@@ -23,63 +23,64 @@
  THE SOFTWARE.
 -->
 
-<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<Configuration>
 
-    <appender name="FILE" class="org.apache.log4j.FileAppender">
-        <param name="File" value="yconnect.log" />
-        <layout class="org.apache.log4j.PatternLayout">
-            <param name="ConversionPattern" value="%d{yyyy/MM/dd HH:mm:ss.SSS} [%p]%r:%m%n" />
-        </layout>
-    </appender>
+    <Appenders>
+        <File name="FILE" fileName="yconnect.log">
+            <PatternLayout>
+                <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} [%p]%r:%m%n</Pattern>
+            </PatternLayout>
+        </File>
+    </Appenders>
 
-    <category name="jp.co.yahoo.yconnect.core.util.YConnectLogger">
-        <priority value="debug" />
-        <appender-ref ref="FILE" />
-    </category>
+    <Loggers>
+        <Logger name="jp.co.yahoo.yconnect.core.util.YConnectLogger">
+            <Level>debug</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
 
-    <category name="org.apache.http.impl.conn.BasicClientConnectionManager">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
+        <Logger name="org.apache.http.impl.conn.BasicClientConnectionManager">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
 
-    <category name="org.apache.http.impl.conn.DefaultClientConnectionOperator">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
+        <Logger name="org.apache.http.impl.conn.DefaultClientConnectionOperator">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
 
-    <category name="org.apache.http.client.protocol.RequestAddCookies">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
+        <Logger name="org.apache.http.client.protocol.RequestAddCookies">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
 
-    <category name="org.apache.http.client.protocol.RequestAuthCache">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-    <category name="org.apache.http.client.protocol.RequestProxyAuthentication">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-    <category name="org.apache.http.impl.client.DefaultHttpClient">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-    <category name="org.apache.http.impl.conn.DefaultClientConnection">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-    <category name="org.apache.http.wire">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-    <category name="org.apache.http.headers">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-    <category name="org.apache.http.client.protocol.ResponseProcessCookies">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-
-</log4j:configuration>
+        <Logger name="org.apache.http.client.protocol.RequestAuthCache">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+        <Logger name="org.apache.http.client.protocol.RequestProxyAuthentication">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+        <Logger name="org.apache.http.impl.client.DefaultHttpClient">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+        <Logger name="org.apache.http.impl.conn.DefaultClientConnection">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+        <Logger name="org.apache.http.wire">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+        <Logger name="org.apache.http.headers">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+        <Logger name="org.apache.http.client.protocol.ResponseProcessCookies">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,8 @@ dependencies {
 
     implementation 'javax.json:javax.json-api:1.0'
     implementation 'javax.servlet:servlet-api:2.5'
-    implementation 'log4j:log4j:1.2.17'
+    implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
     implementation 'org.apache.httpcomponents:httpclient:4.5.2'
     implementation 'org.glassfish:javax.json:1.0.4'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,12 @@ repositories {
 dependencies {
     testImplementation 'junit:junit:4.13.2'
 
-    implementation 'javax.json:javax.json-api:1.0'
+    implementation 'javax.json:javax.json-api:1.1.4'
     implementation 'javax.servlet:servlet-api:2.5'
     implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
     implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.2'
-    implementation 'org.glassfish:javax.json:1.0.4'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+    implementation 'org.glassfish:javax.json:1.1.4'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,20 @@
 plugins {
     id 'java-library'
-    id "com.diffplug.spotless" version "5.17.1"
+    id "com.diffplug.spotless" version "6.11.0"
 }
 
 jar.baseName 'jp.co.yahoo.yconnect'
 version '3.0.0'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_6
-    targetCompatibility = JavaVersion.VERSION_1_6
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+
+}
+
+tasks.withType(JavaCompile) {
+    options.encoding("UTF-8")
 }
 
 repositories {

--- a/yconnect_log_conf.xml
+++ b/yconnect_log_conf.xml
@@ -23,63 +23,65 @@
  THE SOFTWARE.
 -->
 
-<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<Configuration>
 
-    <appender name="FILE" class="org.apache.log4j.FileAppender">
-        <param name="File" value="yconnect.log" />
-        <layout class="org.apache.log4j.PatternLayout">
-            <param name="ConversionPattern" value="%d{yyyy/MM/dd HH:mm:ss.SSS} [%p]%r:%m%n" />
-        </layout>
-    </appender>
+    <Appenders>
+        <File name="FILE" fileName="yconnect.log">
+            <PatternLayout>
+                <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} [%p]%r:%m%n</Pattern>
+            </PatternLayout>
+        </File>
+    </Appenders>
 
-    <category name="jp.co.yahoo.yconnect.core.util.YConnectLogger">
-        <priority value="debug" />
-        <appender-ref ref="FILE" />
-    </category>
+    <Loggers>
+        <Logger name="jp.co.yahoo.yconnect.core.util.YConnectLogger">
+            <Level>debug</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
 
-    <category name="org.apache.http.impl.conn.BasicClientConnectionManager">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
+        <Logger name="org.apache.http.impl.conn.BasicClientConnectionManager">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
 
-    <category name="org.apache.http.impl.conn.DefaultClientConnectionOperator">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
+        <Logger name="org.apache.http.impl.conn.DefaultClientConnectionOperator">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
 
-    <category name="org.apache.http.client.protocol.RequestAddCookies">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
+        <Logger name="org.apache.http.client.protocol.RequestAddCookies">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
 
-    <category name="org.apache.http.client.protocol.RequestAuthCache">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-    <category name="org.apache.http.client.protocol.RequestProxyAuthentication">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-    <category name="org.apache.http.impl.client.DefaultHttpClient">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-    <category name="org.apache.http.impl.conn.DefaultClientConnection">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-    <category name="org.apache.http.wire">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-    <category name="org.apache.http.headers">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
-    <category name="org.apache.http.client.protocol.ResponseProcessCookies">
-        <priority value="warn" />
-        <appender-ref ref="FILE" />
-    </category>
+        <Logger name="org.apache.http.client.protocol.RequestAuthCache">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+        <Logger name="org.apache.http.client.protocol.RequestProxyAuthentication">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+        <Logger name="org.apache.http.impl.client.DefaultHttpClient">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+        <Logger name="org.apache.http.impl.conn.DefaultClientConnection">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+        <Logger name="org.apache.http.wire">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+        <Logger name="org.apache.http.headers">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+        <Logger name="org.apache.http.client.protocol.ResponseProcessCookies">
+            <Level>warn</Level>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+    </Loggers>
 
-</log4j:configuration>
+</Configuration>


### PR DESCRIPTION
In Java11+, there is no way to compile for Java 7.

[java - Intelij Maven : error: Source option 6 is no longer supported. Use 7 or later. Is there anymore solutions? - Stack Overflow](https://stackoverflow.com/questions/66993823/intelij-maven-error-source-option-6-is-no-longer-supported-use-7-or-later-i)

> Java 11+ versions no longer support 1.6 target.

For running on Java17, added these changes:

### Features

* **Logger:** enable logger config file path setting via environment variable ([b7df0fe](https://github.com/suzakulab/yconnect-botlogin-helper/commit/b7df0fee497be117959822e816ed8af5c67c8281))


### Bug Fixes

* **Logger:** migrate Log4j2 from Log4j ([20b9b13](https://github.com/suzakulab/yconnect-botlogin-helper/commit/20b9b137ed8c378de573e405cf3a3b1fbe80ae8f))
* **Logger:** use `log4j2.configurationFile` property if already exists ([e9e1a46](https://github.com/suzakulab/yconnect-botlogin-helper/commit/e9e1a46dcd19a9c646fa0de2483eb56d5339b596))
* **test:** specify file encoding at UTF-8 ([c7886ee](https://github.com/suzakulab/yconnect-botlogin-helper/commit/c7886ee6e62a10669915277507232e1b1e713f17))
* **YConnectLogger:** migrate config Log4j1 into Log4j2 ([e98df0b](https://github.com/suzakulab/yconnect-botlogin-helper/commit/e98df0b551093beec551e9281eac466c93c6b3cb))
