### PR TITLE
Support http proxy

### DIFF
--- a/YConnectServletSDK/src/jp/co/yahoo/yconnect/core/http/YHttpClient.java
+++ b/YConnectServletSDK/src/jp/co/yahoo/yconnect/core/http/YHttpClient.java
@@ -27,6 +27,7 @@ package jp.co.yahoo.yconnect.core.http;
 import jp.co.yahoo.yconnect.core.util.YConnectLogger;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -61,6 +62,10 @@ public class YHttpClient {
      * SSL証明書チェック
      */
     private static boolean checkSSL = true; // default true
+    /**
+     * HTTP Proxy
+     */
+    private static HttpHost httpProxy = null;
     /**
      * {@link HttpURLConnection}インスタンス
      */
@@ -280,7 +285,9 @@ public class YHttpClient {
     private void setSSLConfiguration() {
         if (!checkSSL) {
             YConnectLogger.debug(this, "HTTPS ignore SSL Certification");
-            httpClient = ignoreSSLCertification(HttpClientBuilder.create()).build();
+            httpClient = ignoreSSLCertification(HttpClientBuilder.create())
+                    .setProxy(httpProxy)
+                    .build();
             return;
         }
 
@@ -289,6 +296,7 @@ public class YHttpClient {
             sslContext.init(null, null, null);
             httpClient = HttpClientBuilder.create()
                     .setSSLContext(sslContext)
+                    .setProxy(httpProxy)
                     .build();
         } catch (NoSuchAlgorithmException | KeyManagementException e1) {
             e1.printStackTrace();
@@ -301,5 +309,9 @@ public class YHttpClient {
 
     public static void disableSSLCheck() {
         checkSSL = false;
+    }
+
+    public static void setProxy(String proxyHost, int proxyPort) {
+        httpProxy = new HttpHost(proxyHost, proxyPort);
     }
 }

--- a/YConnectServletSDK/test/build.gradle
+++ b/YConnectServletSDK/test/build.gradle
@@ -18,6 +18,8 @@ repositories {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mock-server:mockserver-client-java:5.14.0'
+    testImplementation 'org.mock-server:mockserver-junit-rule:5.14.0'
 
     implementation 'javax.json:javax.json-api:1.1.4'
     implementation 'javax.servlet:servlet-api:2.5'

--- a/YConnectServletSDK/test/build.gradle
+++ b/YConnectServletSDK/test/build.gradle
@@ -19,11 +19,11 @@ repositories {
 dependencies {
     testImplementation 'junit:junit:4.13.2'
 
-    implementation 'javax.json:javax.json-api:1.0'
+    implementation 'javax.json:javax.json-api:1.1.4'
     implementation 'javax.servlet:servlet-api:2.5'
-    implementation 'log4j:log4j:1.2.17'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.2'
-    implementation 'org.glassfish:javax.json:1.0.4'
+    implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
+    implementation 'org.glassfish:javax.json:1.1.4'
 
     implementation project(':')
 }

--- a/YConnectServletSDK/test/src/jp/co/yahoo/yconnect/core/http/HttpProxyTest.java
+++ b/YConnectServletSDK/test/src/jp/co/yahoo/yconnect/core/http/HttpProxyTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2021 Yahoo Japan Corporation. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jp.co.yahoo.yconnect.core.http;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.socket.PortFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+public class HttpProxyTest {
+    @Rule
+    public MockServerRule r = new MockServerRule(this, proxyPort);
+
+    private static final int proxyPort = PortFactory.findFreePort();
+    private static final String expectBody = "test_proxyed_request";
+
+    @Test
+    public void testRequestProxied() {
+        try (MockServerClient mockServer = new MockServerClient("localhost", proxyPort)) {
+            mockServer.when(
+                            request()
+                                    .withMethod("GET")
+                                    .withPath("/")
+                    )
+                    .respond(
+                            response()
+                                    .withBody(expectBody)
+                    );
+            YHttpClient.setProxy("localhost", proxyPort);
+            YHttpClient.disableSSLCheck();
+            YHttpClient client = new YHttpClient();
+            client.requestGet("https://example.com", null, null);
+
+            assertEquals(client.getResponseBody(), expectBody);
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ repositories {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mock-server:mockserver-client-java:5.14.0'
+    testImplementation 'org.mock-server:mockserver-junit-rule:5.14.0'
 
     implementation 'javax.json:javax.json-api:1.1.4'
     implementation 'javax.servlet:servlet-api:2.5'


### PR DESCRIPTION
### Features

* **YHttpClient:** HTTP Proxyの設定機能 ([964ff90](https://github.com/suzakulab/yconnect-botlogin-helper/commit/964ff9065364297f3707911201ea64d76e73cce9))

### Build Dependency Update

* mockserver追加 ([45e4ea8](https://github.com/suzakulab/yconnect-botlogin-helper/commit/45e4ea8))
* test側のbuild.gradleをプロジェクトルートに追従 ([0924096](https://github.com/suzakulab/yconnect-botlogin-helper/commit/0924096))

### Refactoring

* **YHttpClient:** 非推奨メソッドを置換 ([1238f5b](https://github.com/suzakulab/yconnect-botlogin-helper/commit/1238f5b))

